### PR TITLE
Reduce number of connections by having a different radial search for …

### DIFF
--- a/src/dpg_slam/dpg_slam.h
+++ b/src/dpg_slam/dpg_slam.h
@@ -268,6 +268,20 @@ namespace dpg_slam {
         std::vector<std::pair<Eigen::Vector2f, float>> odom_only_estimates_;
 
         /**
+         * Reoptimize the poses.
+         *
+         * This is an expensive operation where we recompute the scan constraints using the offset between the
+         * estimated pose (instead of using odometry as a seed). This is used between passes to clean up constraints
+         * that reflect poor ICP alignment.
+         */
+        void reoptimize();
+
+        /**
+         * Optimize the pose graph and update the estimated poses in the nodes.
+         */
+        void optimizeGraph();
+
+        /**
          * Determine if the robot has moved far enough that we should compare the last used laser scan to the current
          * laser scan.
          *

--- a/src/dpg_slam/dpg_slam_main.cc
+++ b/src/dpg_slam/dpg_slam_main.cc
@@ -100,6 +100,7 @@ bool run_ = true;
 std::unique_ptr<dpg_slam::DpgSLAM> slam_;
 ros::Publisher visualization_publisher_;
 ros::Publisher localization_publisher_;
+ros::Publisher reoptimization_complete_pub_;
 VisualizationMsg vis_msg_;
 sensor_msgs::LaserScan last_laser_msg_;
 Vector2f prev_odom_;
@@ -184,6 +185,8 @@ void CobotOdometryCallback(const cobot_msgs::CobotOdometryMsg &cobot_msg) {
 void NewPassCallback(const std_msgs::Empty &msg) {
     ROS_INFO_STREAM("New pass!");
     slam_->incrementPassNumber();
+    PublishMap();
+    reoptimization_complete_pub_.publish(std_msgs::Empty());
 }
 
 int gtsam_test(int argc, char** argv) {
@@ -276,6 +279,8 @@ int main(int argc, char** argv) {
       n.advertise<VisualizationMsg>("visualization", 1);
   localization_publisher_ =
       n.advertise<amrl_msgs::Localization2DMsg>("localization", 1);
+  reoptimization_complete_pub_ =
+      n.advertise<std_msgs::Empty>("reoptimization_complete", 1);
 
   ros::Subscriber laser_sub = n.subscribe(
       FLAGS_laser_topic.c_str(),

--- a/src/dpg_slam/parameters.h
+++ b/src/dpg_slam/parameters.h
@@ -95,7 +95,6 @@ namespace dpg_slam {
         PoseGraphParameters(ros::NodeHandle &node_handle) : icp_maximum_iterations_(kDefaultIcpMaximumIterations),
         icp_maximum_transformation_epsilon_(kDefaultIcpMaximumTransformationEpsilon),
         icp_max_correspondence_distance_(kDefaultIcpMaxCorrespondenceDistance),
-        maximum_node_dist_scan_comparison_(kDefaultMaximumNodeDistScanComparison),
         gtsam_max_iterations_(kDefaultGtsamMaxIterations), min_dist_between_nodes_(kDefaultMinDistBetweenNodes),
         min_angle_between_nodes_(kDefaultMinAngleBetweenNodes), new_pass_x_std_dev_(kDefaultNewPassXStdDev),
         new_pass_y_std_dev_(kDefaultNewPassYStdDev), new_pass_theta_std_dev_(kDefaultNewPassThetaStdDev),
@@ -110,7 +109,10 @@ namespace dpg_slam {
             node_handle.param(kIcpMaxCorrespondenceDistanceParamName, icp_max_correspondence_distance_, kDefaultIcpMaxCorrespondenceDistance);
             node_handle.param(kRansacIterationsParamName, ransac_iterations_, kDefaultRansacIterations);
             node_handle.param(kIcpUseReciprocalCorrespondences, icp_use_reciprocal_correspondences_, kDefaultIcpUseReciprocalCorrespondences);
-            node_handle.param(kMaximumNodeDistScanComparisonParamName, maximum_node_dist_scan_comparison_, kDefaultMaximumNodeDistScanComparison);
+            node_handle.param(kMaximumNodeDistWithinPassScanComparisonParamName, maximum_node_dist_within_pass_scan_comparison_,
+                              kDefaultMaximumNodeDistWithinPassScanComparison);
+            node_handle.param(kMaximumNodeDistAcrossPassesScanComparisonParamName, maximum_node_dist_across_passes_scan_comparison_,
+                              kDefaultMaximumNodeDistAcrossPassesScanComparison);
             node_handle.param(kMinDistBetweenNodesParamName, min_dist_between_nodes_, kDefaultMinDistBetweenNodes);
             node_handle.param(kMinAngleBetweenNodesParamName, min_angle_between_nodes_, kDefaultMinAngleBetweenNodes);
             node_handle.param(kNonSuccessiveScanConstraintsParamName, non_successive_scan_constraints_, kDefaultNonsuccessiveScanConstraints);
@@ -194,14 +196,28 @@ namespace dpg_slam {
         static constexpr const char *kIcpUseReciprocalCorrespondences = "icp_use_reciprocal_correspondences";
 
         /**
-         * Default maximum amount that two nodes can be separated by to try to align their scans.
+         * Default maximum amount that two nodes can be separated by to try to align their scans if they are in the same
+         * pass.
          */
-        const float kDefaultMaximumNodeDistScanComparison = 3.0; // TODO tune
+        const float kDefaultMaximumNodeDistWithinPassScanComparison = 5.0; // TODO tune
 
         /**
-         * ROS Param Name for the maximum amount that two nodes can be separated by to try to align their scans.
+         * ROS Param Name for the maximum amount that two nodes can be separated by to try to align their scans if they are in the same
+         * pass.
          */
-        static constexpr const char *kMaximumNodeDistScanComparisonParamName = "maximum_node_dist_scan_comparison_param_name";
+        static constexpr const char *kMaximumNodeDistWithinPassScanComparisonParamName = "maximum_node_dist_within_pass_scan_comparison";
+
+        /**
+         * Default maximum amount that two nodes can be separated by to try to align their scans if they
+         * are in different passes.
+         */
+        const float kDefaultMaximumNodeDistAcrossPassesScanComparison = 2.0; // TODO tune
+
+        /**
+         * ROS Param Name for the maximum amount that two nodes can be separated by to try to align their scans if they
+         * are in different passes.
+         */
+        static constexpr const char *kMaximumNodeDistAcrossPassesScanComparisonParamName = "maximum_node_dist_across_passes_scan_comparison";
 
         /**
          * Default maximum number of iterations for one run of GTSAM estimation.
@@ -451,9 +467,14 @@ namespace dpg_slam {
         // euclidean fitness epsilon?
 
         /**
-         * Maximum amount that two nodes can be separated by to try to align their scans.
+         * Maximum amount that two nodes can be separated by to try to align their scans if they are within the same pass.
          */
-        float maximum_node_dist_scan_comparison_;
+        float maximum_node_dist_within_pass_scan_comparison_;
+
+        /**
+         * Maximum amount that two nodes can be separated by to try to align their scans if they are in different passes.
+         */
+        float maximum_node_dist_across_passes_scan_comparison_;
 
         /**
          * Maximum number of iterations for one run of GTSAM estimation.

--- a/src/icp_cov/cov_func_point_to_point.h
+++ b/src/icp_cov/cov_func_point_to_point.h
@@ -567,7 +567,7 @@ d2J_dxdc    d2J_dydc    d2J_dzdc   d2J_dadc   d2J_dbdc   d2J_dc2
 
 
     // TODO fix this.
-    ROS_INFO_STREAM("Setting output");
+//    ROS_INFO_STREAM("Setting output");
     // TODO probably take the variances from parameters while we're still fixing the main covariance piece.
     ICP_COV.resize(3, 3);
     ICP_COV << laser_x_variance, 0, 0,
@@ -575,7 +575,7 @@ d2J_dxdc    d2J_dydc    d2J_dzdc   d2J_dadc   d2J_dbdc   d2J_dc2
     0, 0, laser_theta_variance;
 
 
-    ROS_INFO_STREAM("Set ICP cov");
+//    ROS_INFO_STREAM("Set ICP cov");
 //
 //    std::cout << "\n\n********************** \n\n" << "6D ICP_COV = \n" << bigger_icp_cov <<"\n*******************\n\n"<< std::endl;
 //


### PR DESCRIPTION
…possible loop closure nodes across passes than within passes; also add a reoptimization that runs between passes and fixes bad ICP constraints

Still need to play around with MIT dataset SLAM params; the in place
rotations result in a lot of nodes, but also the robot can lose track if
those are reduced too significantly; We could consider modifying the
rotation node creation threshold or the within pass distance check
(wouldn't help for very close nodes though). We could have a threshold
for only considering every nth node for loop closures instead of
checking all that are within range